### PR TITLE
Fix build when assets missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ launch.json
 ############################
 #  Copied bundle (embedded)
 ############################
-/internal/assets/build/     
+/internal/assets/build/
+!/internal/assets/build/.gitkeep
 
 ############################
 #  Environment & config


### PR DESCRIPTION
## Summary
- add a `.gitkeep` file under `internal/assets/build` so `go:embed` always has a directory to read from
- adjust `.gitignore` to allow the placeholder

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68402c0383948320b2bffe3d81943169