### PR TITLE
Enable CORS and document Vite dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Erabooru Development Guide
+
+This repository contains a Go backend with a SvelteKit frontend. During development you can run the UI with the Vite dev server for hot reloading while using the existing backend services.
+
+## Prerequisites
+- Docker (for Postgres and MinIO services)
+- Go
+- Node.js and npm
+
+## Starting the stack
+1. Start the databases with Docker Compose:
+   ```sh
+   docker compose up -d
+   ```
+2. In a separate terminal, start the Go API server (for example with [Air](https://github.com/cosmtrek/air)):
+   ```sh
+   air
+   ```
+   The API listens on `http://localhost:8080`.
+3. Run the Vite dev server for the UI:
+   ```sh
+   cd web && npm install && npm run dev
+   ```
+   The UI will be available at `http://localhost:5173` and will communicate with the API.
+
+With this setup you can edit the Svelte application and see changes instantly while still interacting with the backend databases.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,15 +1,29 @@
 package main
 
 import (
-	"era/booru/internal/assets"
-	"net/http"
+        "era/booru/internal/assets"
+        "net/http"
 
-	"github.com/gin-gonic/gin"
+        "github.com/gin-gonic/gin"
 )
 
+func corsMiddleware() gin.HandlerFunc {
+        return func(c *gin.Context) {
+                c.Header("Access-Control-Allow-Origin", "http://localhost:5173")
+                c.Header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
+                c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept")
+                c.Header("Access-Control-Allow-Credentials", "true")
+                if c.Request.Method == http.MethodOptions {
+                        c.AbortWithStatus(http.StatusNoContent)
+                        return
+                }
+                c.Next()
+        }
+}
+
 func main() {
-	r := gin.New()
-	r.Use(gin.Logger(), gin.Recovery())
+        r := gin.New()
+        r.Use(gin.Logger(), gin.Recovery(), corsMiddleware())
 
 	// --- API ---
 	//api := r.Group("/api")


### PR DESCRIPTION
## Summary
- handle CORS requests in the gin server so the frontend can access the API
- document how to use the Vite dev server during development

## Testing
- `go vet ./...` *(fails: downloading go1.24.3)*
- `go test ./...` *(fails: downloading go1.24.3)*
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840305cf6f0832097a5436e54ca471e