### PR TITLE
Add initial media page with upload tab

### DIFF
--- a/web/src/lib/components/MediaGridPlaceholder.svelte
+++ b/web/src/lib/components/MediaGridPlaceholder.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+</script>
+
+<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+	{#each Array.from({ length: 6 }, (_, i) => i) as i (i)}
+		<div class="flex aspect-square items-center justify-center bg-gray-200 text-gray-500">
+			Placeholder {i + 1}
+		</div>
+	{/each}
+</div>

--- a/web/src/lib/components/MediaTabs.svelte
+++ b/web/src/lib/components/MediaTabs.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import MediaGridPlaceholder from './MediaGridPlaceholder.svelte';
+	import UploadArea from './UploadArea.svelte';
+
+	let active: 'media' | 'upload' = 'media';
+</script>
+
+<div>
+	<div class="mb-4 border-b">
+		<nav class="flex space-x-4">
+			<button
+				class="-mb-px border-b-2 px-3 py-2"
+				class:!border-blue-500={active === 'media'}
+				class:!text-blue-500={active === 'media'}
+				class:border-transparent={active !== 'media'}
+				class:text-gray-500={active !== 'media'}
+				on:click={() => (active = 'media')}
+			>
+				Media
+			</button>
+			<button
+				class="-mb-px border-b-2 px-3 py-2"
+				class:!border-blue-500={active === 'upload'}
+				class:!text-blue-500={active === 'upload'}
+				class:border-transparent={active !== 'upload'}
+				class:text-gray-500={active !== 'upload'}
+				on:click={() => (active = 'upload')}
+			>
+				Upload
+			</button>
+		</nav>
+	</div>
+
+	{#if active === 'media'}
+		<MediaGridPlaceholder />
+	{:else}
+		<UploadArea />
+	{/if}
+</div>

--- a/web/src/lib/components/UploadArea.svelte
+++ b/web/src/lib/components/UploadArea.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	let fileInput: HTMLInputElement | null = null;
+
+	function trigger() {
+		fileInput?.click();
+	}
+</script>
+
+<div
+	class="cursor-pointer rounded border-2 border-dashed border-gray-300 p-8 text-center"
+	on:click={trigger}
+	on:keydown={(e) => e.key === 'Enter' && trigger()}
+	role="button"
+	aria-label="Upload file"
+	tabindex="0"
+>
+	<p class="text-gray-500">Click to upload a file</p>
+	<input type="file" class="hidden" bind:this={fileInput} />
+</div>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,3 +1,5 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<script lang="ts">
+	import MediaTabs from '$lib/components/MediaTabs.svelte';
+</script>
 
+<MediaTabs />


### PR DESCRIPTION
## Summary
- add tab layout for media and upload
- show placeholder grid for media files
- implement upload area with basic accessibility
- update home page to render media tabs

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68404322ae0c8320a10fcb67e1d3a1eb