### PR TITLE
Refactor media route handlers

### DIFF
--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// idParam extracts the :id parameter as an int or aborts with BadRequest.
+func idParam(c *gin.Context) (int, bool) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.AbortWithStatus(http.StatusBadRequest)
+		return 0, false
+	}
+	return id, true
+}
+
+// normalizeTags trims, deduplicates and returns clean tag values.
+func normalizeTags(tags []string) []string {
+	seen := map[string]struct{}{}
+	clean := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			clean = append(clean, t)
+		}
+	}
+	return clean
+}

--- a/internal/api/media_name.go
+++ b/internal/api/media_name.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// CreateMediaName validates the file extension and generates a unique object name.
+func CreateMediaName(filename string) (string, error) {
+	extension := filepath.Ext(filename)
+	switch strings.ToLower(extension) {
+	case ".png", ".jpg", ".jpeg", ".gif":
+	default:
+		return "", fmt.Errorf("unsupported file format: %s", extension)
+	}
+	return uuid.New().String() + extension, nil
+}


### PR DESCRIPTION
## Summary
- split large `RegisterMediaRoutes` into individual handlers for easier reuse
- add helper utilities for ID parsing and tag normalization
- keep media name generation in its own file

## Testing
- `make vet`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6853eca2cbe88320a333951e6af5127b