### PR TITLE
Enable auto migrations in dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ MINIO_PUBLIC_PREFIX=/minio
 BLEVE_PATH=/data/bleve
 MINIO_SSL=false
 VIDEO_WORKER_URL=http://video-worker:8080
+DEV_MODE=true

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,6 +13,7 @@ services:
     command: ./scripts/dev.sh
     environment:
       - BLEVE_PATH=/data/bleve
+      - DEV_MODE=true
     volumes:
       - .:/app                      
       - bleve-index:/data/bleve

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	BlevePath             string // path to Bleve index, e.g., "/data/bleve"
 	MinioSSL              bool
 	VideoWorkerURL        string // address of the video worker service
+	DevMode               bool   // enable development features like auto migration
 }
 
 func Load() (*Config, error) {
@@ -44,6 +45,7 @@ func Load() (*Config, error) {
 		BlevePath:             getEnv("BLEVE_PATH", "/data/bleve"),
 		MinioSSL:              getEnv("MINIO_SSL", "false") == "true",
 		VideoWorkerURL:        getEnv("VIDEO_WORKER_URL", "http://video-worker:8080"),
+		DevMode:               getEnv("DEV_MODE", "false") == "true",
 	}
 	return cfg, nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -6,9 +6,11 @@ import (
 
 	"era/booru/ent"
 	"era/booru/ent/hook"
+	"era/booru/ent/migrate"
 	_ "era/booru/ent/runtime"
 	"era/booru/internal/config"
 
+	"entgo.io/ent/dialect/sql/schema"
 	_ "github.com/lib/pq"
 )
 
@@ -21,7 +23,14 @@ func New(cfg *config.Config) (*ent.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := client.Schema.Create(context.Background()); err != nil {
+	opts := []schema.MigrateOption{}
+	if cfg.DevMode {
+		opts = append(opts,
+			migrate.WithDropColumn(true),
+			migrate.WithDropIndex(true),
+		)
+	}
+	if err := client.Schema.Create(context.Background(), opts...); err != nil {
 		return nil, err
 	}
 	client.Media.Use(hook.SyncBleve())


### PR DESCRIPTION
## Summary
- add `DEV_MODE` env variable support
- update dev compose to set `DEV_MODE=true`
- run Ent migrations with drop options when in dev mode

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858d8f10274832084ae50f37a0e18bc