### PR TITLE
Add image embedding worker

### DIFF
--- a/cmd/image_embed_worker/main.go
+++ b/cmd/image_embed_worker/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"era/booru/internal/config"
+	"era/booru/internal/db"
+	embed "era/booru/internal/embeddings"
+	"era/booru/internal/minio"
+	"era/booru/internal/queue"
+	qworkers "era/booru/internal/queue/workers"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	modelDir := os.Getenv("MODEL_DIR")
+	if modelDir == "" {
+		modelDir = "ml_models/Siglip2_INT8"
+	}
+	if err := embed.Load(modelDir); err != nil {
+		log.Fatal(err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	pool, err := pgxpool.New(ctx, cfg.PostgresDSN)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer pool.Close()
+
+	workers := river.NewWorkers()
+	client, err := queue.NewClient(ctx, pool, workers, queue.ClientTypeImageEmbWorker)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	database, err := db.New(cfg, client, false)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	m, err := minio.New(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	river.AddWorker(workers, &qworkers.ImageEmbedWorker{Minio: m, DB: database})
+
+	if err := client.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	<-ctx.Done()
+	client.Stop(context.Background())
+}

--- a/internal/queue/workers/image_embed_worker.go
+++ b/internal/queue/workers/image_embed_worker.go
@@ -1,0 +1,56 @@
+package workers
+
+import (
+	"context"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+
+	"era/booru/ent"
+	"era/booru/internal/db"
+	embed "era/booru/internal/embeddings"
+	"era/booru/internal/minio"
+	"era/booru/internal/queue"
+
+	mc "github.com/minio/minio-go/v7"
+	pgvector "github.com/pgvector/pgvector-go"
+	"github.com/riverqueue/river"
+)
+
+// ImageEmbedWorker generates vision embeddings for images.
+type ImageEmbedWorker struct {
+	river.WorkerDefaults[queue.EmbedArgs]
+	Minio *minio.Client
+	DB    *ent.Client
+}
+
+func (w *ImageEmbedWorker) Work(ctx context.Context, job *river.Job[queue.EmbedArgs]) error {
+	bucket := job.Args.Bucket
+	if bucket == "" {
+		bucket = w.Minio.Bucket
+	}
+
+	obj, err := w.Minio.GetObject(ctx, bucket, job.Args.Key, mc.GetObjectOptions{})
+	if err != nil {
+		return err
+	}
+	defer obj.Close()
+
+	img, _, err := image.Decode(obj)
+	if err != nil {
+		return err
+	}
+
+	vec, err := embed.VisionEmbedding(img)
+	if err != nil {
+		return err
+	}
+
+	pgv := pgvector.NewVector(vec)
+	if err := db.SetMediaVectors(ctx, w.DB, job.Args.Key, []db.VectorValue{{Name: "vision", Value: pgv}}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/queue/workers/media_process_worker.go
+++ b/internal/queue/workers/media_process_worker.go
@@ -128,6 +128,10 @@ func (w *ProcessWorker) processImage(ctx context.Context, bucket, key string) (s
 		return "", err
 	}
 
+	if err := queue.WorkerEnqueue(ctx, queue.EmbedArgs{Bucket: bucket, Key: key}); err != nil {
+		log.Printf("Failed to enqueue embed job for %s: %v", key, err)
+	}
+
 	return key, nil
 }
 


### PR DESCRIPTION
## Summary
- add separate image embedding worker and enqueue job after processing
- extend queue with embed job type and worker configuration
- generate and store image embeddings via SigLIP model

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c32e0297308320844f5ec00ec42788