### PR TITLE
Register embed job stub for non-CGO workers

### DIFF
--- a/cmd/image_embed_worker/main.go
+++ b/cmd/image_embed_worker/main.go
@@ -12,7 +12,7 @@ import (
 	embed "era/booru/internal/embeddings"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
+	embedworker "era/booru/internal/workers/embedworker"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -57,7 +57,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	river.AddWorker(workers, &qworkers.ImageEmbedWorker{Minio: m, DB: database})
+	river.AddWorker(workers, &embedworker.ImageEmbedWorker{Minio: m, DB: database})
 
 	if err := client.Start(ctx); err != nil {
 		log.Fatal(err)

--- a/cmd/media_worker/main.go
+++ b/cmd/media_worker/main.go
@@ -11,7 +11,8 @@ import (
 	"era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
+	indexworker "era/booru/internal/workers/indexworker"
+	mediaworker "era/booru/internal/workers/mediaworker"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
@@ -55,15 +56,17 @@ func main() {
 	}
 
 	// Register worker
-	river.AddWorker(workers, &qworkers.ProcessWorker{
+	river.AddWorker(workers, &mediaworker.ProcessWorker{
 		Minio: m,
 		DB:    database,
 		Cfg:   cfg,
 	})
 
-	river.AddWorker(workers, &qworkers.IndexWorker{
+	river.AddWorker(workers, &indexworker.IndexWorker{
 		DB: database,
 	})
+
+	queue.RegisterEmbedJobStub(workers)
 
 	// Start processing
 	if err := client.Start(ctx); err != nil {

--- a/internal/integration/common/helpers.go
+++ b/internal/integration/common/helpers.go
@@ -18,7 +18,8 @@ import (
 	"era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
+	indexworker "era/booru/internal/workers/indexworker"
+	mediaworker "era/booru/internal/workers/mediaworker"
 )
 
 // ParseExport decompresses the provided gzip data and decodes the exported items.
@@ -89,12 +90,14 @@ func StartMediaWorker(t testing.TB, ctx context.Context, cfg *config.Config) *Me
 		t.Fatalf("minio: %v", err)
 	}
 
-	river.AddWorker(workers, &qworkers.ProcessWorker{
+	river.AddWorker(workers, &mediaworker.ProcessWorker{
 		Minio: m,
 		DB:    database,
 		Cfg:   cfg,
 	})
-	river.AddWorker(workers, &qworkers.IndexWorker{DB: database})
+	river.AddWorker(workers, &indexworker.IndexWorker{DB: database})
+
+	queue.RegisterEmbedJobStub(workers)
 
 	if err := client.Start(ctx); err != nil {
 		t.Fatalf("river start: %v", err)

--- a/internal/queue/embed_stub.go
+++ b/internal/queue/embed_stub.go
@@ -1,0 +1,20 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/riverqueue/river"
+)
+
+// RegisterEmbedJobStub registers a placeholder embed job worker so clients that
+// do not depend on the CGO-enabled embed worker can still enqueue embed jobs.
+//
+// The stub should never run because non-embed services do not poll the embed
+// queue. If it does run, it returns an error to surface the misconfiguration.
+func RegisterEmbedJobStub(workers *river.Workers) {
+	river.AddWorker(workers, river.WorkFunc(func(ctx context.Context, job *river.Job[EmbedArgs]) error {
+		_ = ctx
+		return fmt.Errorf("embed job stub executed for key %q; embed worker not registered in this service", job.Args.Key)
+	}))
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,8 +15,9 @@ import (
 	"era/booru/internal/db"
 	"era/booru/internal/minio"
 	"era/booru/internal/queue"
-	qworkers "era/booru/internal/queue/workers"
 	"era/booru/internal/search"
+	indexworker "era/booru/internal/workers/indexworker"
+	mediaworker "era/booru/internal/workers/mediaworker"
 
 	"github.com/riverqueue/river"
 )
@@ -63,15 +64,16 @@ func New(ctx context.Context, cfg *config.Config) (*Server, error) {
 		return nil, err
 	}
 
-	river.AddWorker(workers, &qworkers.IndexWorker{DB: database})
+	river.AddWorker(workers, &indexworker.IndexWorker{DB: database})
 	if err := riverClient.Start(ctx); err != nil {
 		return nil, err
 	}
-	river.AddWorker(workers, &qworkers.ProcessWorker{
+	river.AddWorker(workers, &mediaworker.ProcessWorker{
 		Minio: m,
 		DB:    database,
 		Cfg:   cfg,
 	})
+	queue.RegisterEmbedJobStub(workers)
 
 	srvCtx, cancel := context.WithCancel(ctx)
 

--- a/internal/workers/embedworker/image_embed_worker.go
+++ b/internal/workers/embedworker/image_embed_worker.go
@@ -1,4 +1,4 @@
-package workers
+package embedworker
 
 import (
 	"context"

--- a/internal/workers/indexworker/index_worker.go
+++ b/internal/workers/indexworker/index_worker.go
@@ -1,4 +1,4 @@
-package workers
+package indexworker
 
 import (
 	"context"

--- a/internal/workers/mediaworker/media_process_worker.go
+++ b/internal/workers/mediaworker/media_process_worker.go
@@ -1,4 +1,4 @@
-package workers
+package mediaworker
 
 import (
 	"context"


### PR DESCRIPTION
## Summary
- add a queue-level helper to register a stub embed worker so non-CGO services can enqueue embed jobs
- call the stub from the media worker binary, server setup, and integration helpers so embed jobs are recognized without importing the CGO embed worker

## Testing
- go test ./...
- go vet ./...
- CGO_ENABLED=0 go build ./cmd/media_worker
- CGO_ENABLED=0 go build ./cmd/server

------
https://chatgpt.com/codex/tasks/task_e_68ca04665bb88320b0a754fa9359bdcf